### PR TITLE
Fix spanish typo

### DIFF
--- a/love.js
+++ b/love.js
@@ -33,7 +33,7 @@
   love.romanian = function() { return 'dragoste'; };
   love.russian = function() { return 'люблю'; };
   love.slovenian = function() { return 'ljubezen'; };
-  love.spanish = function() { return 'amar'; };
+  love.spanish = function() { return 'amor'; };
   love.swedish = function() { return 'älskar'; };
   love.tamil = function() { return 'காதல்'; };
   love.thai = function() { return 'รัก'; };


### PR DESCRIPTION
"amar" is a verb, which would translate to "to love"
"amor" on the other hand, is a noun, which translates to "love"
